### PR TITLE
Adding more personas and roles to the project management processes

### DIFF
--- a/docs/octoacme-project-management-overview.md
+++ b/docs/octoacme-project-management-overview.md
@@ -20,6 +20,8 @@ Applies to all cross-functional projects that deliver product features, services
 - QA/Testing: validate quality and acceptance criteria.
 - Stakeholders: provide inputs and approvals.
 
+Note: We maintain an expanded personas list with cross-functional roles and interaction guidance in docs/octoacme-roles-and-personas.md — please consult that doc for role-level checklists and templates.
+
 ## Key Artifacts
 - Project Charter / One-pager
 - Roadmap and Release Plan

--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -1,6 +1,6 @@
 # OctoAcme Personas
 
-This document defines typical roles and responsibilities used in OctoAcme project docs and exercises.
+This document defines typical roles and responsibilities used in OctoAcme project docs and exercises. It also expands the set of personas to include cross-functional contributors and provides clear interaction points to improve clarity and handoffs.
 
 ---
 
@@ -75,7 +75,151 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 
 ---
 
+## UX Designer / Product Designer
+
+### Role Summary
+Designs user experiences and interfaces that meet user needs and business goals. Helps convert product requirements into usable interfaces.
+
+### Responsibilities
+- Conduct user research and usability testing
+- Produce wireframes, interaction designs, and high-fidelity mocks
+- Collaborate on acceptance criteria related to UX
+- Provide design assets and implementation guidance
+
+### Typical Interactions
+- Works with Product Managers to translate requirements
+- Partners with Developers to ensure feasible implementations
+- Supports QA and PMs during acceptance and reviews
+
+---
+
+## QA Engineer / Test Engineer
+
+### Role Summary
+Ensures product quality through planned testing and verification; supports automation and test strategy.
+
+### Responsibilities
+- Define and execute test plans (unit, integration, e2e where applicable)
+- Build/maintain automated test suites and test data
+- Validate acceptance criteria and regression checks
+- Report and verify fixes and contribute to release readiness
+
+### Typical Interactions
+- Works closely with Developers on testability and bug triage
+- Coordinates with Project Managers and Release Manager for release sign-off
+- Feeds quality findings into retrospectives and planning
+
+---
+
+## Scrum Master / Agile Coach
+
+### Role Summary
+Facilitates the team’s agile process and removes impediments to flow and delivery.
+
+### Responsibilities
+- Facilitate agile ceremonies (standups, planning, retrospectives)
+- Coach teams on agile practices and continuous improvement
+- Help unblock work and improve team dynamics
+
+### Typical Interactions
+- Supports Developers, PMs, and PdMs to keep the team on track
+- Coaches Project Managers and Product Managers on agile tooling and cadence
+- Raises process impediments to leadership as needed
+
+---
+
+## Release Manager
+
+### Role Summary
+Coordinates and validates releases; ensures deployments are planned, communicated, and verified.
+
+### Responsibilities
+- Plan and schedule releases with stakeholders
+- Validate pre-release requirements and checklists
+- Coordinate deployment steps and post-release verification
+- Manage rollback and mitigation plans
+
+### Typical Interactions
+- Works with Developers, QA, and PMs to confirm readiness
+- Communicates release windows and status to Support and Stakeholders
+- Owns release notes and post-release follow-ups
+
+---
+
+## Support Specialist / Customer Support
+
+### Role Summary
+Provides post-release user support, triages incidents, and funnels user feedback back into product and project decisions.
+
+### Responsibilities
+- Triage incoming tickets and incidents
+- Communicate user-impact and reproducible steps to engineering
+- Maintain knowledge base and support documentation
+- Collaborate on incident communications and post-incident follow-up
+
+### Typical Interactions
+- Notifies PdMs and PMs of user-impacting issues
+- Works with Release Manager during incidents
+- Provides input for prioritization of bug fixes
+
+---
+
+## DevOps / Platform Engineer
+
+### Role Summary
+Builds and maintains the infrastructure, CI/CD pipelines, and platform reliability of services.
+
+### Responsibilities
+- Maintain CI/CD, observability, and environment provisioning
+- Support deployments and performance/scalability initiatives
+- Implement infrastructure-as-code and runbook content
+
+### Typical Interactions
+- Works with Developers and Release Manager on pipeline and deployment changes
+- Provides runbooks to Support and PMs for incident handling
+
+---
+
+## Security Champion
+
+### Role Summary
+Represents security best practices within the delivery team and coordinates with central security teams.
+
+### Responsibilities
+- Advise on threat modeling and secure design
+- Triage and validate security findings
+- Ensure required security scans/gates are included in the pipeline
+
+### Typical Interactions
+- Works with Developers, QA, and PdMs to mitigate security concerns
+- Escalates critical security issues to Security on-call
+
+---
+
+## Data Analyst / Data Scientist (where applicable)
+
+### Role Summary
+Supports product discovery and post-release measurement by defining metrics, dashboards, and experiments.
+
+### Responsibilities
+- Define and instrument success metrics and events
+- Build dashboards and run analyses for feature impact
+- Support A/B testing and experiments
+
+### Typical Interactions
+- Collaborates with Product Managers on success metrics
+- Shares findings with PMs and stakeholders to inform prioritization
+
+---
+
+## How to use these personas in our processes
+
+- For new or updated roles, use the role definition template in docs/templates/role-definition-template.md to capture responsibilities, RACI, onboarding notes, and interactions.
+- Use the release-readiness checklist to ensure role-level sign-offs before releases.
+- Review personas during planning and kickoff to ensure owners are assigned for each deliverable.
+
+---
+
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.
 - Each persona can be used as a persona prompt for Copilot Spaces to shape role-specific guidance.
-

--- a/docs/templates/release-readiness-checklist.md
+++ b/docs/templates/release-readiness-checklist.md
@@ -1,0 +1,36 @@
+# Release Readiness Checklist
+
+Use this checklist to confirm role-level signoffs before a release.
+
+Release: [name / number]
+Date: [YYYY-MM-DD]
+Prepared by: [Release Manager]
+
+Pre-release checks
+- [ ] Acceptance criteria for all release items met (PdM / Feature Owner)
+- [ ] CI green and security scans passed (Developers / DevOps)
+- [ ] QA sign-off on release candidate (QA Engineer)
+- [ ] UX/Design review completed for UI changes (UX Designer)
+- [ ] Performance smoke test results acceptable (DevOps / Developers)
+- [ ] Rollback / mitigation plan documented (Release Manager)
+- [ ] Release notes drafted (Release Manager / PdM)
+- [ ] Support readiness: support docs, runbooks, and escalation contacts confirmed (Support Specialist)
+- [ ] Stakeholders notified of window and expected impact (Project Manager)
+
+Role approvals (initial / date)
+- Product Manager (PdM): _______
+- Project Manager (PM): _______
+- Release Manager: _______
+- QA Engineer: _______
+- DevOps / Platform: _______
+- Support Specialist: _______
+- Security Champion (if security-affecting): _______
+
+Post-release checks
+- [ ] Smoke tests passed in production (Release Manager / DevOps)
+- [ ] Monitoring dashboards validated (DevOps / Data Analyst)
+- [ ] Customer-impacting issues logged and triaged (Support Specialist)
+- [ ] Post-release retrospective scheduled (PM / PdM)
+
+Notes & exceptions:
+- [Add any exceptions or manual verification steps here]

--- a/docs/templates/role-definition-template.md
+++ b/docs/templates/role-definition-template.md
@@ -1,0 +1,21 @@
+# Role Definition Template
+
+Use this template when adding or updating a persona/role in docs/octoacme-roles-and-personas.md.
+
+- Role name:
+- Short summary (1-2 lines):
+- Responsibilities (bullet list):
+- Goals / success metrics:
+- Typical interactions (who they work with and when):
+- RACI summary (Responsible / Accountable / Consulted / Informed) for major project activities:
+  - Requirement definition:
+  - Implementation:
+  - Testing & QA:
+  - Release:
+  - Support / Incident handling:
+- Onboarding notes / quick links (runbooks, tools, dashboards):
+- Suggested acceptance criteria for role-related work (e.g., documentation, handoffs):
+- Example tasks owned by this role:
+
+Example usage:
+- Add a new section to docs/octoacme-roles-and-personas.md and paste the filled template as the role definition.


### PR DESCRIPTION
Summary

    Expands docs/octoacme-roles-and-personas.md with additional cross-functional personas (UX Designer, QA Engineer, Scrum Master/Agile Coach, Release Manager, Support Specialist, DevOps/Platform Engineer, Security Champion, Data Analyst) and clear interactions with existing roles.
    Adds templates: docs/templates/role-definition-template.md and docs/templates/release-readiness-checklist.md to standardize role definitions and release signoffs.
    Adds a pointer from project-management-overview to the expanded personas doc.

Why

    Addresses gaps in the roles documentation identified in issue #4 (improves clarity, accountability, and handoffs; supports onboarding and release readiness).

Related: #4 Labels: documentation, process improvement 